### PR TITLE
Fix UI of post deletion (when we only have one post)

### DIFF
--- a/src/components/home/Home.jsx
+++ b/src/components/home/Home.jsx
@@ -49,7 +49,6 @@ export default function Home() {
     // State change will cause component re-render
     async function fetchPublicPosts() {
       const output = await getPublicPosts(authorId, page, size);
-      if (output.posts.length == 0) { return; }
       setInbox(output.posts);
       setNumPages(Math.ceil(output.count/size));
     }


### PR DESCRIPTION
- Remove a line that would cause `My Posts`'s UI to not update after deletion (when we only have one post in `My Post`)